### PR TITLE
Changed INGA examples for LED usage

### DIFF
--- a/examples/inga/demo/button_demo.c
+++ b/examples/inga/demo/button_demo.c
@@ -36,8 +36,7 @@ PROCESS_THREAD(default_app_process, ev, data)
   SENSORS_ACTIVATE(button_sensor);
 
   leds_init();	
-  leds_on(LEDS_GREEN);
-  leds_on(LEDS_YELLOW);
+  leds_on(LEDS_GREEN | LEDS_YELLOW); // turn both LEDs on at once
   etimer_set(&timer,  CLOCK_SECOND*0.05);
   while (1) {
 

--- a/examples/inga/demo/led_demo.c
+++ b/examples/inga/demo/led_demo.c
@@ -41,8 +41,7 @@ PROCESS_THREAD(default_app_process, ev, data)
 		
 		PROCESS_YIELD();
 		etimer_set(&timer,  CLOCK_SECOND);
-		leds_toggle(LEDS_GREEN);
-		leds_toggle(LEDS_YELLOW);
+		leds_toggle(LEDS_GREEN | LEDS_YELLOW); // toggle both LEDs at once using bitwise or
 
         }
 


### PR DESCRIPTION
The LED driver was changed in 7f48057b9e63b6b819954b001619058c3b6cc4f3. This resulted in our demos not working anymore.

Also, I changed the LED calls to show new users how LEDs can be used in a more convenient way.
