### PR TITLE
Inga makefile

### DIFF
--- a/platform/inga/Makefile.inga
+++ b/platform/inga/Makefile.inga
@@ -215,6 +215,9 @@ login:
 	$(SERIALDUMP) -b$(INGA_CONF_BAUDRATE) $(firstword $(CMOTES))
 
 %.upload_setup: %.hex
+ifeq ($(strip $(MOTES)),)
+	$(error no motes found)
+endif
 	$(eval UPLOAD_TARGET=$*)
 	@echo Uploading...
 


### PR DESCRIPTION
Fixed the inga Makefile, to get actual failures, if the upload process was not successful.
Parallelization is now done by -j with make (if necessary)
