### PR TITLE
[inga] examples/inga-regression/net-tests-rime: made the code compiling ...

### DIFF
--- a/examples/inga-regression/net-tests-rime/Makefile
+++ b/examples/inga-regression/net-tests-rime/Makefile
@@ -1,14 +1,14 @@
 # RIME unicast test
 rime-unicast-sender: rime_unicast_sender
-	
+
 rime-unicast-receiver: rime_unicast_receiver
-	
+
 
 # RIME broadcast test
 
-TARGET=inga
+TARGET = inga
 
-APPS = settings_set  
+APPS = settings_set
 
 PROJECT_SOURCEFILES += ../test.c
 

--- a/examples/inga-regression/net-tests-rime/rime_unicast_receiver.c
+++ b/examples/inga-regression/net-tests-rime/rime_unicast_receiver.c
@@ -1,7 +1,8 @@
 #include "contiki.h"
-#include "net/rime.h"
+#include "net/rime/rime.h"
 
 #include <stdio.h>
+#include <string.h>
 #include "../test.h"
 #include "test-params.h"
 
@@ -14,7 +15,7 @@ PROCESS(rime_unicast_sender, "Example unicast");
 AUTOSTART_PROCESSES(&rime_unicast_sender);
 /*---------------------------------------------------------------------------*/
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   char *datapntr;
   static uint8_t rec_count = 0;

--- a/examples/inga-regression/net-tests-rime/rime_unicast_sender.c
+++ b/examples/inga-regression/net-tests-rime/rime_unicast_sender.c
@@ -3,9 +3,10 @@
  */
 
 #include "contiki.h"
-#include "net/rime.h"
+#include "net/rime/rime.h"
 
 #include <stdio.h>
+#include <string.h>
 #include "../test.h"
 #include "test-params.h"
 
@@ -18,7 +19,7 @@ PROCESS(rime_unicast_sender, "Rime Unicast Sender");
 AUTOSTART_PROCESSES(&rime_unicast_sender);
 /*---------------------------------------------------------------------------*/
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   static uint8_t rec_count = 0;
 
@@ -47,7 +48,7 @@ PROCESS_THREAD(rime_unicast_sender, ev, data)
   unicast_open(&uc, 146, &unicast_callbacks); // channel = 145
 
   static struct etimer et;
-  static rimeaddr_t addr;
+  static linkaddr_t addr;
 
   etimer_set(&et, 2*CLOCK_SECOND);
 


### PR DESCRIPTION
...again

The code used old struct-names and include paths. therefore failed compiling, when I needed an example implementation of rime unicast
