### PR TITLE
avr: EEPROM now is updated instead of written regardless of content

### DIFF
--- a/cpu/avr/dev/eeprom.c
+++ b/cpu/avr/dev/eeprom.c
@@ -64,7 +64,7 @@ eeprom_write(eeprom_addr_t addr, unsigned char *buf, int size)
     }
   }
 
-  eeprom_write_block(buf, (unsigned short *)addr, size);
+  eeprom_update_block(buf, (unsigned short *)addr, size);
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
Changing EEPROM cells wears them out as they have a limited amount of write cycles. For the ATMEGA1284p this is 100000 cycles for example.

The AVR EEPROM driver is changed so that it only updates cells that actually get a new content by the write access. This introduces the need to read the cell beforehand which makes the whole operation a bit slower, but in my opinion the speed of an eeprom access (which is used mostly for configuration that does not change very often) is not as important as to preserve cell that are accidentally written more often than needed, eg. in a fast running loop.

This PR is a possible fix for the issue #23.
