### PR TITLE
[cooja/serialsocket] Do not throw UnsupportedOperationException()

### DIFF
--- a/tools/cooja/apps/serial_socket/java/org/contikios/cooja/serialsocket/SerialSocketClient.java
+++ b/tools/cooja/apps/serial_socket/java/org/contikios/cooja/serialsocket/SerialSocketClient.java
@@ -335,7 +335,7 @@ public class SerialSocketClient extends VisPlugin implements MotePlugin {
 
   @Override
   public void packPlugin(JDesktopPane pane) {
-    throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    pack();
   }
   
   public interface ClientListener {

--- a/tools/cooja/apps/serial_socket/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
+++ b/tools/cooja/apps/serial_socket/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
@@ -339,7 +339,7 @@ public class SerialSocketServer extends VisPlugin implements MotePlugin {
 
   @Override
   public void packPlugin(JDesktopPane pane) {
-    throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    pack();
   }
   
   public interface ServerListener {


### PR DESCRIPTION
Added `pack()` call to `packPlugin()` and removed exception throwing.
This issue was caused by merging with mainline version of SerialSocket.
