### PR TITLE
Fixed wrong icon URL of the jenkins build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 The INGA sensor platform on Contiki-OS.
 =======================================
 
-[![Build Status](https://jenkins.ibr.cs.tu-bs.de/jenkins/buildStatus/icon?job=inga--develop--cooja)](http://jenkins.ibr.cs.tu-bs.de/jenkins/view/INGA/job/inga--develop--compile/)
+[![Build Status](https://jenkins.ibr.cs.tu-bs.de/jenkins/buildStatus/icon?job=inga--develop--compile)](http://jenkins.ibr.cs.tu-bs.de/jenkins/view/INGA/job/inga--develop--compile/)
 
 INGA is an Open Source Wireless Sensor Node for many different applications. 
 INGA was developed at IBR as Inexpensive Node for General Applications and became part of many projects.


### PR DESCRIPTION
I'm not sure why this happened in 6d1cddd, this changes it to the same job the URL points out to
