### PR TITLE
platform/inga: Fixed wrong whitespace in Makefile.inga

### DIFF
--- a/platform/inga/Makefile.inga
+++ b/platform/inga/Makefile.inga
@@ -204,7 +204,7 @@ else
 	$(warning resetting not supported)
 endif
 else
-  $(warning Auto resetting disbaled)
+	$(warning Auto resetting disbaled)
 endif
 
 login:


### PR DESCRIPTION
Nothing to add here, mixed up tabs and spaces causing an invalid Makefile, this fixes it
