### PR TITLE
Contiki config fix

### DIFF
--- a/platform/inga/contiki-conf.h
+++ b/platform/inga/contiki-conf.h
@@ -175,7 +175,9 @@
 
 #else /* UIP_CONF_IPV6 */
 /* ip4 should build but is largely untested */
+#ifndef NETSTACK_CONF_NETWORK
 #define NETSTACK_CONF_NETWORK     rime_driver
+#endif
 
 #define LINKADDR_CONF_SIZE        2
 

--- a/platform/inga/contiki-conf.h
+++ b/platform/inga/contiki-conf.h
@@ -49,6 +49,11 @@
 
 #include <avr/eeprom.h>
 
+/* Include the project config.
+ * PROJECT_CONF_H might be defined in the project Makefile */
+#ifdef PROJECT_CONF_H
+#include PROJECT_CONF_H
+#endif /* PROJECT_CONF_H */
 /* Skip the last four bytes of the EEPROM, to leave room for things
  * like the avrdude erase count and bootloader signaling. */
 #define EEPROM_CONF_SIZE   ((E2END + 1) - 4)
@@ -285,10 +290,5 @@
 #define CC_CONF_INLINE inline
 #endif 
 
-/* Include the project config.
- * PROJECT_CONF_H might be defined in the project Makefile */
-#ifdef PROJECT_CONF_H
-#include PROJECT_CONF_H
-#endif /* PROJECT_CONF_H */
 
 #endif /* __CONTIKI_CONF_H__ */


### PR DESCRIPTION
This includes the project_conf.h at the very top of the contiki_conf.h to enable it to overwrite the stetting with project specific  ones. Also added an ifndef around NETSTACK_CONF_NETWORK for the same reason.
