### PR TITLE
Fixes network configuration in platform to be compatible to changes from upstream

### DIFF
--- a/examples/inga-regression/net-tests-ip/Makefile
+++ b/examples/inga-regression/net-tests-ip/Makefile
@@ -3,12 +3,11 @@ alltests: udp_ipv6_client udp_ipv6_server
 	
 TARGET=inga
 
-UIP_CONF_IPV6=1
-
 APPS = settings_set  
 EUI64=00:00:00:00:00:00:00:00
 
 PROJECT_SOURCEFILES += ../test.c
 
 CONTIKI = ../../..
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/inga-regression/settings-tests/Makefile
+++ b/examples/inga-regression/settings-tests/Makefile
@@ -3,11 +3,10 @@ alltests: udp_ipv6_client udp_ipv6_server
 	
 TARGET=inga
 
-UIP_CONF_IPV6=1
-
 PROJECT_SOURCEFILES += ../test.c
 
 APPS = settings_set settings_delete
 
 CONTIKI = ../../..
+CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/inga/demo/Makefile
+++ b/examples/inga/demo/Makefile
@@ -1,11 +1,7 @@
 CONTIKI_PROJECT = inga-demo
 all: $(CONTIKI_PROJECT)
-uip-unicast: uip_unicast
 	
 CFLAGS += -DWITH_NODE_ID=1
-
-#CFLAGS += ‐DWITH_UIP=1
-UIP_CONF_IPV6=1
 
 ifdef NODE_ID
 	CFLAGS +=-DNODEID=$(NODE_ID)
@@ -15,4 +11,6 @@ TARGET=inga
 APPS = settings_set settings_delete
 
 CONTIKI = ../../..
+# Choose NETSTACK here, IPV6 is default 
+# CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/inga/net/Makefile
+++ b/examples/inga/net/Makefile
@@ -2,8 +2,7 @@ all: udp_ipv6_client udp_ipv6_server
 
 TARGET=inga
 
-# Only for uip examples
-UIP_CONF_IPV6=1
-
 CONTIKI = ../../..
+# Change to IPV6 if needed
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/platform/inga/Makefile.inga
+++ b/platform/inga/Makefile.inga
@@ -128,7 +128,7 @@ AVRDUDE_PROGRAMMER=avr109
 # Verify off
 #AVRDUDE_OPTIONS=-V
 # Baudrate
-AVRDUDE_OPTIONS=-b 230400
+AVRDUDE_OPTIONS=-b 230400 -u
 
 
 ### JTAG programming
@@ -244,5 +244,5 @@ endif
 include $(CONTIKIAVR)/Makefile.avr
 include $(CONTIKIAVR)/radio/Makefile.radio
 
-MODULES += core/net/ip core/net/ipv6 core/net/mac core/net core/net/rime core/net/mac/sicslowmac core/net/rpl \
+MODULES +=  core/net/mac core/net core/net/mac/sicslowmac \
            core/net/llsec

--- a/platform/inga/contiki-conf.h
+++ b/platform/inga/contiki-conf.h
@@ -144,7 +144,7 @@
 /*
  * Network stack setup.
  */
-#if UIP_CONF_IPV6
+#if NETSTACK_CONF_WITH_IPV6
 #define NETSTACK_CONF_NETWORK     sicslowpan_driver
 
 #define LINKADDR_CONF_SIZE        8
@@ -168,13 +168,13 @@
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_1 {addr_contexts[1].prefix[0]=0xbb;addr_contexts[1].prefix[1]=0xbb;}
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_2 {addr_contexts[2].prefix[0]=0x20;addr_contexts[2].prefix[1]=0x01;addr_contexts[2].prefix[2]=0x49;addr_contexts[2].prefix[3]=0x78,addr_contexts[2].prefix[4]=0x1d;addr_contexts[2].prefix[5]=0xb1;}
 
-#else /* UIP_CONF_IPV6 */
+#else /* NETSTACK_CONF_WITH_IPV6 */
 /* ip4 should build but is largely untested */
 #define NETSTACK_CONF_NETWORK     rime_driver
 
 #define LINKADDR_CONF_SIZE        2
 
-#endif /* UIP_CONF_IPV6 */
+#endif /* NETSTACK_CONF_WITH_IPV6 */
 
 /* -- Radio driver settings */
 #define CHANNEL_802_15_4          26

--- a/platform/inga/contiki-inga-main.c
+++ b/platform/inga/contiki-inga-main.c
@@ -101,12 +101,12 @@ uint8_t debugflowsize, debugflow[DEBUGFLOWSIZE];
 #include "cfs/coffee/cfs-coffee.h"
 #endif
 
-#if UIP_CONF_IPV6
+#if NETSTACK_CONF_WITH_IPV6
 #include "net/ipv6/uip-ds6.h"
 // function declaration for net/uip-debug.c
 void uip_debug_ipaddr_print(const uip_ipaddr_t *addr);
 void uip_debug_lladdr_print(const uip_lladdr_t *addr);
-#endif /* UIP_CONF_IPV6 */
+#endif /* NETSTACK_CONF_WITH_IPV6 */
 
 
 // Apps 
@@ -311,15 +311,15 @@ load_config(void)
   /* Overwrite with node id if set */
   if (node_id > 0) {
     PRINTD("Using Node ID (0x%04x) to overwrite address settings!\n", node_id);
-#if UIP_CONF_IPV6
+#if NETSTACK_CONF_WITH_IPV6
     memset(inga_cfg.eui64_addr, 0, sizeof(inga_cfg.eui64_addr));
     inga_cfg.eui64_addr[0] |= 0x02; // set U/L bit to 1 (local!)
     inga_cfg.eui64_addr[6] = (node_id >> 8);
     inga_cfg.eui64_addr[7] = node_id & 0xFF;
-#else /* UIP_CONF_IPV6 */
+#else /* NETSTACK_CONF_WITH_IPV6 */
     inga_cfg.eui64_addr[0] = node_id & 0xFF;
     inga_cfg.eui64_addr[1] = (node_id >> 8);
-#endif /* UIP_CONF_IPV6 */
+#endif /* NETSTACK_CONF_WITH_IPV6 */
     inga_cfg.pan_addr = node_id;
 
     /* Configuration done */
@@ -555,7 +555,7 @@ init(void)
   platform_radio_init();
 #endif
 
-#if UIP_CONF_IPV6
+#if NETSTACK_CONF_WITH_IPV6
   // Copy EUI64 to the link local address
   memcpy(&uip_lladdr.addr, &(inga_cfg.eui64_addr), sizeof(uip_lladdr.addr));
 
@@ -576,7 +576,7 @@ init(void)
 #endif
 #endif /* INGA_BOOTSCREEN_NET */
 
-#endif /* UIP_CONF_IPV6 */
+#endif /* NETSTACK_CONF_WITH_IPV6 */
 
 #if INGA_BOOTSCREEN_NET
   PRINTA_SEC("Link layer info:\n");

--- a/platform/inga/inga-conf.h
+++ b/platform/inga/inga-conf.h
@@ -105,7 +105,7 @@
 #define INGA_PERIODIC_ROUTES 0
 #else
 #define INGA_PERIODIC_ROUTES INGA_CONF_PERIODIC_ROUTES
-#if INGA_PERIODIC_ROUTES > 0 && !UIP_CONF_IPV6
+#if INGA_PERIODIC_ROUTES > 0 && !NETSTACK_CONF_WITH_IPV6
 #error Periodic routes only supported for IPv6
 #endif
 #endif


### PR DESCRIPTION
With pull-req #864 some changes in upstream were made how the network stack in configured:

"Harmonize config parameters: now using CONTIKI_WITH_IPV6, 
 CONTIKI_WITH_IPV4, CONTIKI_WITH_RIME in makefiles, and 
 UIP_CONF_IPV6, UIP_CONF_IPV4 and UIP_CONF_RIME in c code. 
 No more UIP_CONF_* in makefiles. No more WITH_UIP nor 
 WITH_UIP6 anywhere. IPv6 the new default."

This had to be made in our platform too to be compatible with the repo parts from upstream. 
Without this compiling failed for all tested programs (led/button_demo, tests,...), because some defines/declarations are missing in the network stack.