### PR TITLE
Fixes some errors in rime unicast examples and rime test

### DIFF
--- a/examples/inga-regression/net-tests-rime/Makefile
+++ b/examples/inga-regression/net-tests-rime/Makefile
@@ -13,4 +13,5 @@ APPS = settings_set
 PROJECT_SOURCEFILES += ../test.c
 
 CONTIKI = ../../..
+CONTIKI_WITH_RIME = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/inga-regression/net-tests-rime/rime_unicast_sender.c
+++ b/examples/inga-regression/net-tests-rime/rime_unicast_sender.c
@@ -45,7 +45,7 @@ PROCESS_THREAD(rime_unicast_sender, ev, data)
   PROCESS_BEGIN();
 
 
-  unicast_open(&uc, 146, &unicast_callbacks); // channel = 145
+  unicast_open(&uc, 146, &unicast_callbacks); // channel = 146
 
   static struct etimer et;
   static linkaddr_t addr;
@@ -55,8 +55,7 @@ PROCESS_THREAD(rime_unicast_sender, ev, data)
   PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
 
   // set address
-  addr.u8[0] = NET_TEST_CFG_TARGET_NODE_ID & 0xFF;
-  addr.u8[1] = NET_TEST_CFG_TARGET_NODE_ID >> 8;
+  addr.u16 = UIP_HTONS(NET_TEST_CFG_TARGET_NODE_ID);
 
   // send 10 messages
   static int8_t idx = 0;
@@ -68,7 +67,7 @@ PROCESS_THREAD(rime_unicast_sender, ev, data)
     sprintf(buff_, NET_TEST_CFG_REQUEST_MSG, idx);
     packetbuf_copyfrom(buff_ , NET_TEST_CFG_REQUEST_MSG_LEN); 
     unicast_send(&uc, &addr);
-    printf("sent: %s\n", buff_);
+    printf("sent: %s to %x.%x \n", buff_, addr.u8[0], addr.u8[1]  );
   }
 
   PROCESS_END();

--- a/examples/inga/net/rime_unicast_receiver.c
+++ b/examples/inga/net/rime_unicast_receiver.c
@@ -4,8 +4,8 @@
 #include <stdio.h>
 
 /*---------------------------------------------------------------------------*/
-PROCESS(rime_unicast_sender, "Example unicast");
-AUTOSTART_PROCESSES(&rime_unicast_sender);
+PROCESS(rime_unicast_receiver, "Rime Unicast Receiver");
+AUTOSTART_PROCESSES(&rime_unicast_receiver);
 /*---------------------------------------------------------------------------*/
 static void
 recv_uc(struct unicast_conn *c, const linkaddr_t *from)
@@ -14,14 +14,14 @@ recv_uc(struct unicast_conn *c, const linkaddr_t *from)
   datapntr = packetbuf_dataptr();
   datapntr[15] = '\0';
 
-  printf("unicast message received from %d.%d: '%s'\n", from->u8[0], from->u8[1], datapntr);
+  printf("unicast message received from %x.%x: '%s'\n", from->u8[0], from->u8[1], datapntr);
 }
 
 static const struct unicast_callbacks unicast_callbacks = {recv_uc}; // List of Callbacks to be called if a message has been received.
 static struct unicast_conn uc;
 /*---------------------------------------------------------------------------*/
 
-PROCESS_THREAD(rime_unicast_sender, ev, data)
+PROCESS_THREAD(rime_unicast_receiver, ev, data)
 {
   PROCESS_EXITHANDLER(unicast_close(&uc));
 

--- a/examples/inga/net/rime_unicast_receiver.c
+++ b/examples/inga/net/rime_unicast_receiver.c
@@ -2,7 +2,9 @@
 #include "net/rime/rime.h"
 
 #include <stdio.h>
+#include <avr/pgmspace.h>
 
+#define PRINTF(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
 /*---------------------------------------------------------------------------*/
 PROCESS(rime_unicast_receiver, "Rime Unicast Receiver");
 AUTOSTART_PROCESSES(&rime_unicast_receiver);

--- a/examples/inga/net/rime_unicast_receiver.c
+++ b/examples/inga/net/rime_unicast_receiver.c
@@ -1,5 +1,5 @@
 #include "contiki.h"
-#include "net/rime.h"
+#include "net/rime/rime.h"
 
 #include <stdio.h>
 
@@ -8,7 +8,7 @@ PROCESS(rime_unicast_sender, "Example unicast");
 AUTOSTART_PROCESSES(&rime_unicast_sender);
 /*---------------------------------------------------------------------------*/
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   char *datapntr;
   datapntr = packetbuf_dataptr();

--- a/examples/inga/net/rime_unicast_sender.c
+++ b/examples/inga/net/rime_unicast_sender.c
@@ -11,7 +11,6 @@
 
 // TODO: Change ADDR to your receiver node, eg. lookup link addr on receiver boot
 #define RECEIVER_LINK_ADDR 0x04d6
-
 #define PRINTF(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
 /*---------------------------------------------------------------------------*/
 PROCESS(rime_unicast_sender, "Rime Unicast Sender");
@@ -45,8 +44,9 @@ PROCESS_THREAD(rime_unicast_sender, ev, data)
     packetbuf_copyfrom("Unicast Example", 15); // String + Length to be send
 
     // Address of receiving Node
-    addr.u8[0] = RECEIVER_LINK_ADDR & 0xFF;
-    addr.u8[1] = RECEIVER_LINK_ADDR >> 8;
+    addr.u16 = UIP_HTONS(RECEIVER_LINK_ADDR);
+    /*addr.u8[0] = RECEIVER_LINK_ADDR >> 8;*/
+    /*addr.u8[1] = RECEIVER_LINK_ADDR & 0xFF;*/
 
     if (!linkaddr_cmp(&addr, &linkaddr_node_addr)) {
       PRINTF("Message sent\n"); // debug message

--- a/examples/inga/net/rime_unicast_sender.c
+++ b/examples/inga/net/rime_unicast_sender.c
@@ -7,10 +7,12 @@
 #include "net/rime/rime.h"
 
 #include <stdio.h>
+#include <avr/pgmspace.h>
 
 // TODO: Change ADDR to your receiver node, eg. lookup link addr on receiver boot
 #define RECEIVER_LINK_ADDR 0x04d6
 
+#define PRINTF(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
 /*---------------------------------------------------------------------------*/
 PROCESS(rime_unicast_sender, "Rime Unicast Sender");
 AUTOSTART_PROCESSES(&rime_unicast_sender);

--- a/examples/inga/net/rime_unicast_sender.c
+++ b/examples/inga/net/rime_unicast_sender.c
@@ -1,11 +1,15 @@
 /**
  * @author Robert Hartung, hartung@ibr.cs.tu-bs.de
+ * @author Dennis Reimers, d.reimers@tu-bs.de
  */
 
 #include "contiki.h"
 #include "net/rime/rime.h"
 
 #include <stdio.h>
+
+// TODO: Change ADDR to your receiver node, eg. lookup link addr on receiver boot
+#define RECEIVER_LINK_ADDR 0x04d6
 
 /*---------------------------------------------------------------------------*/
 PROCESS(rime_unicast_sender, "Rime Unicast Sender");
@@ -14,7 +18,7 @@ AUTOSTART_PROCESSES(&rime_unicast_sender);
 static void
 recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
-  printf("unicast message received from %d.%d: '%s'\n", from->u8[0], from->u8[1], (char *) packetbuf_dataptr());
+  PRINTF("unicast message received from %x.%x: '%s'\n", from->u8[0], from->u8[1], (char *) packetbuf_dataptr());
 }
 
 static const struct unicast_callbacks unicast_callbacks = {recv_uc};
@@ -26,7 +30,7 @@ PROCESS_THREAD(rime_unicast_sender, ev, data)
 
   PROCESS_BEGIN();
 
-  unicast_open(&uc, 146, &unicast_callbacks); // channel = 145
+  unicast_open(&uc, 146, &unicast_callbacks); // channel = 146
 
   while (1) {
     static struct etimer et;
@@ -38,11 +42,12 @@ PROCESS_THREAD(rime_unicast_sender, ev, data)
 
     packetbuf_copyfrom("Unicast Example", 15); // String + Length to be send
 
-    addr.u8[0] = 13; // Address of receiving Node
-    addr.u8[1] = 0;
+    // Address of receiving Node
+    addr.u8[0] = RECEIVER_LINK_ADDR & 0xFF;
+    addr.u8[1] = RECEIVER_LINK_ADDR >> 8;
 
     if (!linkaddr_cmp(&addr, &linkaddr_node_addr)) {
-      printf("Message sent\n"); // debug message
+      PRINTF("Message sent\n"); // debug message
       unicast_send(&uc, &addr);
     }
   }

--- a/examples/inga/net/rime_unicast_sender.c
+++ b/examples/inga/net/rime_unicast_sender.c
@@ -3,7 +3,7 @@
  */
 
 #include "contiki.h"
-#include "net/rime.h"
+#include "net/rime/rime.h"
 
 #include <stdio.h>
 
@@ -12,7 +12,7 @@ PROCESS(rime_unicast_sender, "Rime Unicast Sender");
 AUTOSTART_PROCESSES(&rime_unicast_sender);
 /*---------------------------------------------------------------------------*/
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   printf("unicast message received from %d.%d: '%s'\n", from->u8[0], from->u8[1], (char *) packetbuf_dataptr());
 }
@@ -30,7 +30,7 @@ PROCESS_THREAD(rime_unicast_sender, ev, data)
 
   while (1) {
     static struct etimer et;
-    rimeaddr_t addr;
+    linkaddr_t addr;
 
     etimer_set(&et, CLOCK_SECOND);
 
@@ -41,7 +41,7 @@ PROCESS_THREAD(rime_unicast_sender, ev, data)
     addr.u8[0] = 13; // Address of receiving Node
     addr.u8[1] = 0;
 
-    if (!rimeaddr_cmp(&addr, &rimeaddr_node_addr)) {
+    if (!linkaddr_cmp(&addr, &linkaddr_node_addr)) {
       printf("Message sent\n"); // debug message
       unicast_send(&uc, &addr);
     }


### PR DESCRIPTION
- Path of header is corrected
- rimeaddr_t to linkaddr_t
- solve problem with link addr byte order by using UIP_HTONS
- some minor improvements like PRINTF macro using avr pgm printf