### PR TITLE
[Makefile] Adds terminal target to Makefile.inga

### DIFF
--- a/platform/inga/Makefile.inga
+++ b/platform/inga/Makefile.inga
@@ -220,6 +220,15 @@ endif
 %.upload_target: %.reset
 	avrdude $(AVRDUDE_OPTIONS) -P $* $(AVRDUDE_PROGRAMMER) -p $(MCU) -U flash:w:$(UPLOAD_TARGET).hex
 
+terminal: reset
+	@echo "Opening avrdude terminal mode on "$(firstword $(CMOTES))
+	avrdude $(AVRDUDE_OPTIONS) -P $(firstword $(CMOTES)) $(AVRDUDE_PROGRAMMER) -p $(MCU) -t
+
+terminal_bang: reset
+	@echo "Opening avrdude terminal mode with bitbang on "$(firstword $(CMOTES))
+	avrdude -c $(AVRDUDE_BITBANG_PROGRAMMER) -p $(MCU) -C +$(CONTIKI)/platform/inga/avrdude_bitbang.conf -b 1000 & wait $!
+	avrdude -c $(AVRDUDE_BITBANG_PROGRAMMER) -p $(MCU) -C +$(CONTIKI)/platform/inga/avrdude_bitbang.conf -t $!
+
 %.upload: %.hex %.upload_setup
 	$(MAKE) UPLOAD_TARGET=$(UPLOAD_TARGET) $(UPLOAD_MOTE_TARGETS)
 	@echo Upload done.


### PR DESCRIPTION
This target opens avrdude in interactive terminal mode for writing/dumping
the fuses/flash/eeprom manually.

Usage:
With bootloader:
  make terminal MOTES="/dev/inga/node-..."
With bitbanging
  make terminal_bang MOTES="/dev/inga/node-..."

TODO: Improve handling with more than one device in MOTES
Currently only the first device in MOTELIST is selected for terminal
connection, but all devices will be reset.