### PR TITLE
Pull req/new eui64 calculation and node setup

### DIFF
--- a/examples/inga/node-setup/Makefile
+++ b/examples/inga/node-setup/Makefile
@@ -6,11 +6,18 @@ APPS += settings_set
 APPS += settings_delete
 
 # Preset default values
-EUI64 =
+#EUI64 =
 PAN_ADDR =
 PAN_ID =
 RADIO_CHANNEL = 
 RADIO_TX_POWER = 
+
+CONTIKI = ../../..
+
+# Check environment values and set to defined default if not set
+ifndef EUI64
+	EUI64=$($(CONTIKI)/tools/inga/inga_tool/inga_tool -e -d $(MOTES) | cut -d":" -f2-)
+endif
 
 setup: SETTINGS_SET_LOAD = 1
 setup: SETTINGS_DELETE_LOAD = 0
@@ -45,6 +52,5 @@ test-single:
 	@test ! $(NR_OF_MOTES) -eq 0 || (echo "*** At least one MOTE required. Specify with MOTES=<device>" && false)
 	@test $(NR_OF_MOTES) -eq 1 || (echo "*** Only single MOTE allowed. Specify with MOTES=<device>" && false)
 
-CONTIKI = ../../..
 include $(CONTIKI)/Makefile.include
 

--- a/examples/inga/node-setup/Makefile
+++ b/examples/inga/node-setup/Makefile
@@ -16,7 +16,7 @@ CONTIKI = ../../..
 
 # Check environment values and set to defined default if not set
 ifndef EUI64
-	EUI64=$($(CONTIKI)/tools/inga/inga_tool/inga_tool -e -d $(MOTES) | cut -d":" -f2-)
+	EUI64 = $(shell $(CONTIKI)/tools/inga/inga_tool/inga_tool -e -d $(MOTES) | cut -d":" -f2-)
 endif
 
 setup: SETTINGS_SET_LOAD = 1

--- a/examples/inga/node-setup/Makefile
+++ b/examples/inga/node-setup/Makefile
@@ -6,18 +6,14 @@ APPS += settings_set
 APPS += settings_delete
 
 # Preset default values
-#EUI64 =
 PAN_ADDR =
-PAN_ID =
-RADIO_CHANNEL = 
-RADIO_TX_POWER = 
+PAN_ID = 0xABCD
+RADIO_CHANNEL = 26
+RADIO_TX_POWER = 0
 
 CONTIKI = ../../..
 
-# Check environment values and set to defined default if not set
-ifndef EUI64
-	EUI64 = $(shell $(CONTIKI)/tools/inga/inga_tool/inga_tool -e -d $(MOTES) | cut -d":" -f2-)
-endif
+all: setup
 
 setup: SETTINGS_SET_LOAD = 1
 setup: SETTINGS_DELETE_LOAD = 0
@@ -53,4 +49,30 @@ test-single:
 	@test $(NR_OF_MOTES) -eq 1 || (echo "*** Only single MOTE allowed. Specify with MOTES=<device>" && false)
 
 include $(CONTIKI)/Makefile.include
+
+# Check environment values and set to defined default if not set
+ifndef EUI64
+  $(info [$(CONTIKI_PROJECT)] EUI64 is undefined. Trying to calculate one with inga_tool)
+  ifneq ($(MOTES),)
+    EUI64_FROM_USB = $(shell $(INGA_TOOL) -e -d $(MOTES) | cut -d":" -f2- | sed -e 's/^[ \t]*//')
+    ifneq ($(EUI64_FROM_USB),)
+      EUI64 ?= $(EUI64_FROM_USB)
+      CONF_EUI64 := $(shell echo $(EUI64) | sed 's/\([0-9a-fA-F]\{2\}\)/0x\1/g' | sed 's/:/,/g')
+      CFLAGS += -DINGA_CONF_EUI64=$(CONF_EUI64)
+      $(info [$(CONTIKI_PROJECT)] EUI64 will be set to $(EUI64))
+    else
+      $(error [$(CONTIKI_PROJECT)] EUI64 calculation failed.)
+    endif
+  endif
+endif
+
+ifeq ($(PAN_ADDR),)
+  $(info [$(CONTIKI_PROJECT)] PAN ADDR is empty. Using last 2 bytes of EUI64)
+  PAN_ADDR_FROM_EUI = 0x$(shell echo $(EUI64) | cut -d":" -f7,8 | sed -e 's/://g')
+  ifneq ($(PAN_ADDR_FROM_EUI),)
+    PAN_ADDR = $(PAN_ADDR_FROM_EUI)
+    CFLAGS += -DINGA_CONF_PAN_ADDR=$(PAN_ADDR)
+    $(info [$(CONTIKI_PROJECT)] PAN ADDR will be set to $(PAN_ADDR))
+  endif
+endif
 

--- a/examples/inga/node-setup/README.md
+++ b/examples/inga/node-setup/README.md
@@ -4,12 +4,14 @@ Set up INGA
 Use this to setup nodes with default values for node id, pan id, channel and tx power.
 Settings will be written to EEPROM when the program starts.
 
-usage: make [target] [MOTES=<device>] NODE_ID=<value> [options]
+usage: make [target] [MOTES=<device>] [options]
 Targets:
 - setup(default): Setup with given values
 - delete:  Delete all settings
+
 Options:
-- EUI64=<value>           default=none
+- EUI64=<value>           default calculated by inga_tool from FTDI serial
+- PAN_ADDR=<value>        default last 2 bytes of EUI64
 - PAN_ID=<value>          default=0xABCD
 - RADIO_CHANNEL=<value>   default=26
 - RADIO_TX_POWER=<value>  default=0
@@ -19,13 +21,13 @@ Example
 
 If only one node is connected to your computer, you can run
 
-    make NODE_ID=<your-id> setup
+    make setup
 
 If multiple nodes are connected, you have to specify which node to set
 
-    make NODE_ID=<your-id> MOTES=/dev/ttyUSBx setup
+    make MOTES=/dev/ttyUSBx setup
 
 To check your settings instantly after programming, you can add the login target
 
-    make NODE_ID=<your-id> MOTES=/dev/ttyUSBx setup login
+    make MOTES=/dev/ttyUSBx setup login
 

--- a/platform/inga/apps/settings_set/Makefile.settings_set
+++ b/platform/inga/apps/settings_set/Makefile.settings_set
@@ -3,34 +3,39 @@ settings_set_src = settings_set.c
 # Note: this variable can be modified by setting target-specific variable
 SETTINGS_SET_LOAD=1
 
+# Inform about loading of app
+$(info [APP.settings_set] loaded with:)
 # PAN_ADDR
 ifdef PAN_ADDR
- CFLAGS += -DINGA_CONF_PAN_ADDR=$(PAN_ADDR)
+  $(info [APP.settings_set] PAN_ADDR: "$(PAN_ADDR)")
+  CFLAGS += -DINGA_CONF_PAN_ADDR=$(PAN_ADDR)
 endif
 
 # PANID
 ifdef PAN_ID
- CFLAGS += -DINGA_CONF_PAN_ID=$(PAN_ID)
+  $(info [APP.settings_set] PAN_ID: "$(PAN_ID)")
+  CFLAGS += -DINGA_CONF_PAN_ID=$(PAN_ID)
 endif
 
 # RADIO CHANNEL
 ifdef RADIO_CHANNEL
- CFLAGS += -DINGA_CONF_RADIO_CHANNEL=$(RADIO_CHANNEL)
+  $(info [APP.settings_set] RADIO_CHANNEL: "$(RADIO_CHANNEL)")
+  CFLAGS += -DINGA_CONF_RADIO_CHANNEL=$(RADIO_CHANNEL)
 endif
 
 # RADIO TX POWER
 ifdef RADIO_TX_POWER
- CFLAGS += -DINGA_CONF_RADIO_TX_POWER=$(RADIO_TX_POWER)
+  $(info [APP.settings_set] RADIO_TX_POWER: "$(RADIO_TX_POWER)")
+  CFLAGS += -DINGA_CONF_RADIO_TX_POWER=$(RADIO_TX_POWER)
 endif
 
 # EUI64
 ifdef EUI64
+  $(info [APP.settings_set] EUI64: "$(EUI64)")
   CONF_EUI64 := $(shell echo $(EUI64) | sed 's/\([0-9a-fA-F]\{2\}\)/0x\1/g' | sed 's/:/,/g')
   CFLAGS += -DINGA_CONF_EUI64=$(CONF_EUI64)
 endif
 
-# Inform about loading of app
-$(info [APP.settings_set] loaded)
 # Activate app if needed
 CFLAGS+=-DAPP_SETTINGS_SET=$(SETTINGS_SET_LOAD)
 

--- a/tools/inga/inga_tool/inga_tool.c
+++ b/tools/inga/inga_tool/inga_tool.c
@@ -223,11 +223,19 @@ uint64_t inga_serial_to_id(const char * serial)
 			character = 42;
 		}
 
-		return_value = (return_value << 6) | (character & 0x3F);
+    /*printf("serial[%d]: 0x%x (%c) character[%d]: 0x%x \n", i, serial[i], serial[i], i, character);*/
+
+		return_value = (return_value << 3) | (character & 0x3F);
 	}
 
 	/* Insert FFFE as required by http://msdn.microsoft.com/en-us/library/aa915616.aspx */
-	return_value = ((return_value & 0xFFFFFF000000) << 16) | (((uint64_t) 0xFEFF) << 24) | (return_value & 0x00000000FFFFF);
+	/*return_value = ((return_value & 0xFFFFFF000000) << 16) | (((uint64_t) 0xFEFF) << 24) | (return_value & 0x00000000FFFFF);*/
+  /*return_value = ((return_value << 24)& 0x000000EFFF252494); */
+  /*return_value &= 0x0000000000FFFFFF;*/
+
+  /*printf("return_value 0x%x\n", return_value);*/
+  return_value = (return_value << 40) | 0x000000FEFF524249; 
+  /*printf("return_value 0x%x\n", return_value);*/
 
 	/* Insert 00 */
 	return_value &= 0xFFFFFFFFFFFFFF7F;

--- a/tools/inga/inga_tool/inga_tool.c
+++ b/tools/inga/inga_tool/inga_tool.c
@@ -216,7 +216,7 @@ uint64_t inga_serial_to_id(const char * serial)
 	int character = 0;
 	uint64_t return_value = 0;
 
-	for(i=0; i<8; i++) {
+	for(i=8; i>0; i--) {
 		character = serial[i] - 48; // "0" == 48, Z == 42
 
 		if( character > 42 ) {


### PR DESCRIPTION
This adds a new way how EUI64 are calculated.
changes made:
- inga_tool: eui64 calculation
- inga-setup: default settings

EUI64:
- starts with: `0x49 0x42 0x52` (= ascii 'I' 'B' 'R' )
- then: `0xff 0xfe` (as defined in standard)
- rest: characters from FTDI serial number

default settings:
- EUI64 from inga_tool
- PAN_ADDR from EUI64
- rest is defined in node-setup/Makefile